### PR TITLE
Enable threaded conversations and isolated memories for bot @mentions

### DIFF
--- a/SRC/app.py
+++ b/SRC/app.py
@@ -75,8 +75,13 @@ def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.L
     
     # Store user_message and get bot response
     bot_message = add_chain_link(channel_id, body, loc="mentions")
+
     # Send generated response back to Slack
-    say(bot_message)
+    # say(bot_message)
+
+    # Send generated response back in a thread
+    thread_timestamp = body["event"]["ts"]
+    say(bot_message, thread_ts = thread_timestamp)
 
 
 # ====================================

--- a/SRC/app.py
+++ b/SRC/app.py
@@ -67,7 +67,11 @@ def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.L
         logging object
     """
     # ID for channel message received from
-    channel_id = body["event"]["channel"]
+    # Set thread timestamp as channel ID 
+    try:
+        channel_id = body["event"]["thread_ts"]
+    except KeyError:
+        channel_id = body["event"]["ts"]
     
     # If no chain exists for this channel, create new one
     if not channel_id in THREADS_DICT:
@@ -75,9 +79,6 @@ def handle_app_mention_events(body: dict, say: slack_bolt.Say, logger: logging.L
     
     # Store user_message and get bot response
     bot_message = add_chain_link(channel_id, body, loc="mentions")
-
-    # Send generated response back to Slack
-    # say(bot_message)
 
     # Send generated response back in a thread
     thread_timestamp = body["event"]["ts"]


### PR DESCRIPTION
This PR serves to change the functionality of the 'app_mention' event, so that @mentions at the bot will cause the bot to respond to the message in a new thread, instead of in a channel.

Once an @mention is made to the bot, it will start a new thread and continue the conversation in that thread. The @mention messages in the newly created thread, as well as the bot replies, are all treated as 'thread conversation', regardless of which user messages the bot within that thread.

Furthermore, the implementation ensures that the bot keeps the memory of each thread isolated.

To facilitate this, the following changes were made to the 'app_mention' event:

- The 'channel_id' variable has been changed to use the thread timestamp as identifier. It is my suggestion to perhaps rename this variable to 'thread_id' in a future update.
- The 'say' method has been extended with an additional parameter called 'thread_ts', which allows specifying the thread timestamp. The thread timestamp is then passed as an argument when invoking the 'say' method.

The changes were tested and work as expected.