### PR TITLE
refactor: Move system prompts to model-based dict

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from utils.system_prompts import SYSTEM_PROMPTS_DICT
 
 MODEL = "meta-llama/Llama-2-13b-chat-hf"
 # MODEL = "mistralai/Mistral-7B-Instruct-v0.1"
@@ -6,22 +7,15 @@ MODEL = "meta-llama/Llama-2-13b-chat-hf"
 # MODEL = "zero-one-ai/Yi-34B-Chat"
 # IMAGE_MODEL = "stabilityai/stable-diffusion-2-1"
 
+# Select system prompt based on model in use
+SYSTEM_PROMPT = SYSTEM_PROMPTS_DICT[MODEL]
+
+# Set model parameters
 MAX_TOKENS = 1024
 TEMPERATURE = 0.1
 TOP_K = 5
 TOP_P = 0.7
 REPETITION_PENALTY = 1.1
-
-SYSTEM_PROMPT = """
-<s>[INST]<<SYS>>
-You are an AI assistant having a conversation with a human.
-Use concise and professional language to respond.
-Respond directly, do not thank the human for their question when you reply.
-If you do not know the answer to a question, state truthfully that you do not know.
-
-{history}<</SYS>>
-{input}[/INST]
-"""
 
 # Not in use - for reference only
 CHATBOTS = {

--- a/src/utils/system_prompts.py
+++ b/src/utils/system_prompts.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# ====================================
+# Prompt versions
+# ====================================
+
+# LLaMA-2 and Mistral models
+sys_p01_meta_mistral = """
+<s>[INST]<<SYS>>
+You are an AI assistant having a conversation with a human.
+Use concise and professional language to respond.
+Respond directly, do not thank the human for their question when you reply.
+If you do not know the answer to a question, state truthfully that you do not know.
+
+{history}<</SYS>>
+{input}[/INST]
+"""
+
+# Stanford Alpaca model
+sys_p02_stanford = """
+<s>[INST]<<SYS>>
+You are an AI assistant having a conversation with a human.
+Use concise and professional language to respond.
+Respond directly, do not thank the human for their question when you reply.
+If you do not know the answer to a question, state truthfully that you do not know.
+
+{history}<</SYS>>
+{input}[/INST]
+"""
+
+# 01 Yi model
+sys_p03_zeroone = """
+<s>[INST]<<SYS>>
+You are an AI assistant having a conversation with a human.
+Use concise and professional language to respond.
+Respond directly, do not thank the human for their question when you reply.
+If you do not know the answer to a question, state truthfully that you do not know.
+
+{history}<</SYS>>
+{input}[/INST]
+"""
+
+# ====================================
+# Prompts dict
+# ====================================
+
+SYSTEM_PROMPTS_DICT = {
+    "meta-llama/Llama-2-13b-chat-hf": sys_p01_meta_mistral, 
+    "mistralai/Mistral-7B-Instruct-v0.1": sys_p01_meta_mistral, 
+    "togethercomputer/alpaca-7b": sys_p02_stanford, 
+    "zero-one-ai/Yi-34B-Chat": sys_p03_zeroone, 
+    
+}


### PR DESCRIPTION
Moves from a single system prompt, to a dictionary of system prompts with model names as keys.

This will permit dynamic selection of the appropriate system prompt, based on the model in use.

System prompts are now located in `src/system_prompts.py`.

The `SYSTEM_PROMPT` variable now passes the model name to `SYSTEM_PROMPTS_DICT`, which is imported into `config.py`.