### PR TITLE
feat: Add working prompt for alpaca-7b

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from utils.system_prompts import SYSTEM_PROMPTS_DICT
 
-MODEL = "meta-llama/Llama-2-13b-chat-hf"
+# MODEL = "meta-llama/Llama-2-13b-chat-hf"
 # MODEL = "mistralai/Mistral-7B-Instruct-v0.1"
-# MODEL = "togethercomputer/alpaca-7b"
+MODEL = "togethercomputer/alpaca-7b"
 # MODEL = "zero-one-ai/Yi-34B-Chat"
 # IMAGE_MODEL = "stabilityai/stable-diffusion-2-1"
 
@@ -19,5 +19,6 @@ REPETITION_PENALTY = 1.1
 
 # Not in use - for reference only
 CHATBOTS = {
-    "U06S474L338": "csbm-bot"
+    "U06S474L338": "csbm-bot",
+    "U06T5FVMMKL": "Yi-34B-Chat"
 }

--- a/src/utils/system_prompts.py
+++ b/src/utils/system_prompts.py
@@ -18,14 +18,14 @@ If you do not know the answer to a question, state truthfully that you do not kn
 
 # Stanford Alpaca model
 sys_p02_stanford = """
-<s>[INST]<<SYS>>
 You are an AI assistant having a conversation with a human.
 Use concise and professional language to respond.
 Respond directly, do not thank the human for their question when you reply.
 If you do not know the answer to a question, state truthfully that you do not know.
 
-{history}<</SYS>>
-{input}[/INST]
+{history}
+### Human: {input}
+### Assistant: 
 """
 
 # 01 Yi model
@@ -49,5 +49,4 @@ SYSTEM_PROMPTS_DICT = {
     "mistralai/Mistral-7B-Instruct-v0.1": sys_p01_meta_mistral, 
     "togethercomputer/alpaca-7b": sys_p02_stanford, 
     "zero-one-ai/Yi-34B-Chat": sys_p03_zeroone, 
-    
 }


### PR DESCRIPTION
This PR adds a new prompt template for the `alpaca-7b` model.

It is similar to the template in use for `Llama-2-13b-chat-hf` and `Mistral-7B-Instruct-v0.1`, but does not use tag tokens, and uses hashtags as cues for the human and assistant content.