### PR TITLE
Enable threaded conversations and isolated memories for bot direct messaging in App section of Slack

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,11 @@ def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) 
         logging object
     """
     # ID for channel message received from
-    channel_id = message["channel"]
+    # Set thread timestamp as channel ID 
+    try:
+        channel_id = message["thread_ts"]
+    except KeyError:
+        channel_id = message["ts"]
     
     # If no chain exists for this channel, create new one
     if not channel_id in THREADS_DICT:
@@ -46,8 +50,10 @@ def message_handler(message: dict, say: slack_bolt.Say, logger: logging.Logger) 
     
     # Store user_message and get bot response
     bot_message = add_chain_link(channel_id, message, loc="apps")
-    # Send generated response back to Slack
-    say(bot_message)
+    
+    # Send generated response back in a thread
+    thread_timestamp = message["ts"]
+    say(bot_message, thread_ts = thread_timestamp)
 
 
 @app.event(("app_mention"))


### PR DESCRIPTION
This PR serves to change the functionality of the direct message event, so that direct conversations with the bot in Apps will cause the bot to respond to the message in a new thread, instead of in the App chat UI.

Once a message is sent to the bot, it will start a new thread and continue the conversation in that thread. The messages in the newly created thread, as well as the bot replies, are all treated as 'thread conversation'.

Furthermore, the implementation ensures that the bot keeps the memory of each thread isolated.

To facilitate this, the following changes were made to the '@app.message(".*")' event:

- The 'channel_id' variable has been changed to use the thread timestamp as identifier. It is my suggestion to perhaps rename this variable to 'thread_id' in a future update.
- The 'say' method has been extended with an additional parameter called 'thread_ts', which allows specifying the thread timestamp. The thread timestamp is then passed as an argument when invoking the 'say' method.

The changes were tested and work as expected.